### PR TITLE
Symfony 3.x Compatibility:

### DIFF
--- a/Command/SecurityDebugAclObjectCommand.php
+++ b/Command/SecurityDebugAclObjectCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  *  ACL Objects debug command
@@ -91,7 +92,7 @@ EOF
             $access = $acl->isGranted($masks, array($securityIdentity), false) ? 'Allow' : 'Deny';
         }
 
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(array('Mask', 'Grant', 'Deny'));
         $table->setRows($results);
         $table->render($output);

--- a/Command/SecurityDebugAclVotersCommand.php
+++ b/Command/SecurityDebugAclVotersCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Egulias\SecurityDebugCommandBundle\Security\Voter\VotersDebug;
 use Egulias\SecurityDebugCommandBundle\Security\Authorization\DecisionManagerDebug;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  *  Voters debug command
@@ -87,7 +88,7 @@ EOF
         );
 
         $output->writeln($formattedLine);
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(array('Class', 'Abstain', 'Grant', 'Deny'));
         $votes = $votersDebug->getVotersVote($token);
 

--- a/Command/SecurityDebugFirewallsCommand.php
+++ b/Command/SecurityDebugFirewallsCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Egulias\SecurityDebugCommandBundle\HttpKernel\SimpleHttpKernel;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  * @author Eduardo Gulias <me@egulias.com>
@@ -51,7 +52,7 @@ EOF
         $session = $this->getContainer()->get('session');
         $session->setName('security.debug.console');
         $session->set('_security_' . $firewallProvider, serialize($token));
-        $this->getContainer()->get('security.context')->setToken($token);
+        $this->getContainer()->get('security.token_storage')->setToken($token);
 
         $kernel = new SimpleHttpKernel();
         $request = Request::create($uri, 'GET', array(), array('security.debug.console' => true));
@@ -77,7 +78,7 @@ EOF
             sprintf('Firewall <comment>%s</comment> listeners', $firewallProvider)
         );
         $output->writeln($formattedLine);
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(array('Class', 'Stopped propagation'));
         $firewallContext = $map->getContext();
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);

--- a/Command/SecurityDebugVotersCommand.php
+++ b/Command/SecurityDebugVotersCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Egulias\SecurityDebugCommandBundle\Security\Voter\VotersDebug;
 use Egulias\SecurityDebugCommandBundle\Security\Authorization\DecisionManagerDebug;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  *  Voters debug command
@@ -71,7 +72,7 @@ EOF
         );
 
         $output->writeln($formattedLine);
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(array('Class', 'Abstain', 'Grant', 'Deny'));
         $votes = $votersDebug->getVotersVote($token);
 

--- a/DataCollector/FirewallCollector.php
+++ b/DataCollector/FirewallCollector.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
 /**
  * Class AccessDeniedListener
@@ -18,14 +18,14 @@ class FirewallCollector
 {
     const HAS_RESPONSE = SecurityDebugDataCollector::DENIED;
 
-    private $securityContext;
+    private $tokenStorage;
     private $container;
 
     public function __construct(
-        SecurityContextInterface $securityContext,
+        TokenStorage $tokenStorage,
         Container $container
     ) {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         //Container dependency is a bad thing. This is to be refactored to a compiler pass
         //where all the firewall providers will be fetched
         $this->container = $container;
@@ -33,7 +33,7 @@ class FirewallCollector
 
     public function collect(Request $request, \Exception $exception)
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if (!method_exists($token, 'getProviderKey')) {
             return;
         }

--- a/DataCollector/VotersCollector.php
+++ b/DataCollector/VotersCollector.php
@@ -3,7 +3,7 @@
 namespace Egulias\SecurityDebugCommandBundle\DataCollector;
 
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Egulias\SecurityDebugCommandBundle\Security\Voter\VotersDebug;
 
@@ -14,20 +14,20 @@ use Egulias\SecurityDebugCommandBundle\Security\Voter\VotersDebug;
 class VotersCollector
 {
     private $accessDecisionManager;
-    private $securityContext;
+    private $tokenStorage;
 
     public function __construct(
         AccessDecisionManagerInterface $decisionManager,
-        SecurityContextInterface $securityContext
+        TokenStorage $tokenStorage
     ) {
         $this->accessDecisionManager = $decisionManager;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
     }
 
     public function collect()
     {
         $votersDebug = new VotersDebug($this->accessDecisionManager);
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
 
         if (!$token || !$token->isAuthenticated()) {
             return;

--- a/EventListener/SecurityListenersDebugListener.php
+++ b/EventListener/SecurityListenersDebugListener.php
@@ -29,6 +29,11 @@ class SecurityListenersDebugListener
         if (!$event->getException() instanceof AccessDeniedException) {
             return;
         }
+
+        if (gettype($event->getRequest()->get('_controller')) == 'string') {
+            return;
+        }
+
         $controller = $event->getRequest()->get('_controller');
         $controllerEvent = new FilterControllerEvent(
             $event->getKernel(),

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ $ php composer.phar update egulias/security-debug-command-bundle
   // app/AppKernel.php
   public function registerBundles()
   {
-    return array(
-      // ...
-      new Egulias\SecurityDebugCommandBundle\EguliasSecurityDebugCommandBundle(),
-      // ...
-      );
+    // ...
+    if (in_array($this->getEnvironment(), array('dev', 'test'))) { 
+      $bundle[] = Egulias\SecurityDebugCommandBundle\EguliasSecurityDebugCommandBundle();
+    }
+    // ...
   }
 ```
 ## Configure the user class

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,17 +1,17 @@
 services:
     egulias.voters_collector:
         class: Egulias\SecurityDebugCommandBundle\DataCollector\VotersCollector
-        arguments: [@security.access.decision_manager, @security.context]
+        arguments: ["@security.access.decision_manager", "@security.token_storage"]
     egulias.firewall_collector:
         class: Egulias\SecurityDebugCommandBundle\DataCollector\FirewallCollector
-        arguments: [@security.context, @service_container]
+        arguments: ["@security.token_storage", "@service_container"]
     egulias.security_listeners_debug:
         class: Egulias\SecurityDebugCommandBundle\EventListener\SecurityListenersDebugListener
-        arguments: [@sensio_framework_extra.security.listener, @data_collector.egulias_security_debug]
+        arguments: ["@sensio_framework_extra.security.listener", "@data_collector.egulias_security_debug"]
         tags:
           - {name: kernel.event_listener, event: kernel.exception, priority: 128}
     data_collector.egulias_security_debug:
         class: Egulias\SecurityDebugCommandBundle\DataCollector\SecurityDebugDataCollector
-        arguments: [@egulias.voters_collector, @egulias.firewall_collector]
+        arguments: ["@egulias.voters_collector", "@egulias.firewall_collector"]
         tags:
             - { name: data_collector, template: "EguliasSecurityDebugCommandBundle:Collector:security_debug", id: "egulias_security_debug"}


### PR DESCRIPTION
 - Updated usage of table helper (deprecated in 3.x) in commands to Table class.
 - Updated references to security context (deprecated in 3.x) to token storage.
 - Updated readme, should only register bundle in dev and test environments where it is intended to be used.

You may wish to create new tag/branch for this version as there are unavoidable BC breaks due to deprecation in Symfony 3. 